### PR TITLE
Add command waiting and minimum download queue size

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,18 +98,21 @@ My 12-year-old daughter is passionate about singing, dancing, and exploring STEM
 
 The following environment variables can be configured:
 
-| Variable                     | Description                                                              | Default    |
-|------------------------------|-----------------------------------------------------------------------|---------------|
-| `API_KEY`                    | Your Sonarr API key                                                      | Required   |
-| `API_URL`                    | URL to your Sonarr instance                                              | Required   |
-| `API_TIMEOUT`                | Timeout in seconds for API requests to Sonarr                            | 60         |
-| `MONITORED_ONLY`             | Only process monitored shows/episodes                                    | true       |
-| `HUNT_MISSING_SHOWS`         | Maximum missing shows to process per cycle                               | 1          |
-| `HUNT_UPGRADE_EPISODES`      | Maximum upgrade episodes to process per cycle                            | 0          |
-| `SLEEP_DURATION`             | Seconds to wait after completing a cycle (900 = 15 minutes)              | 900        |
-| `RANDOM_SELECTION`           | Use random selection (`true`) or sequential (`false`)                    | true       |
-| `STATE_RESET_INTERVAL_HOURS` | Hours which the processed state files reset (168=1 week, 0=never reset)  | 168        |
-| `DEBUG_MODE`                 | Enable detailed debug logging (`true` or `false`)                        | false      |
+| Variable                      | Description                                                              | Default    |
+|-------------------------------|-----------------------------------------------------------------------|---------------|
+| `API_KEY`                     | Your Sonarr API key                                                      | Required   |
+| `API_URL`                     | URL to your Sonarr instance                                              | Required   |
+| `API_TIMEOUT`                 | Timeout in seconds for API requests to Sonarr                            | 60         |
+| `MONITORED_ONLY`              | Only process monitored shows/episodes                                    | true       |
+| `HUNT_MISSING_SHOWS`          | Maximum missing shows to process per cycle                               | 1          |
+| `HUNT_UPGRADE_EPISODES`       | Maximum upgrade episodes to process per cycle                            | 0          |
+| `SLEEP_DURATION`              | Seconds to wait after completing a cycle (900 = 15 minutes)              | 900        |
+| `RANDOM_SELECTION`            | Use random selection (`true`) or sequential (`false`)                    | true       |
+| `STATE_RESET_INTERVAL_HOURS`  | Hours which the processed state files reset (168=1 week, 0=never reset)  | 168        |
+| `DEBUG_MODE`                  | Enable detailed debug logging (`true` or `false`)                        | false      |
+| `COMMAND_WAIT_DELAY`          | Delay in seconds between checking for command status                     | 1          |
+| `COMMAND_WAIT_ATTEMPTS`       | Number of attempts to check for command completeion before giving up     | 600        |
+| `MINIMUM_DOWNLOAD_QUEUE_SIZE` | Minimum number of items in the download queue before starting a hunt     | -1         |
 
 ### Detailed Configuration Explanation
 
@@ -145,6 +148,20 @@ The following environment variables can be configured:
 - **DEBUG_MODE**
   - When set to `true`, the script will output detailed debugging information about API responses and internal operations.
   - Useful for troubleshooting issues but can make logs verbose.
+
+- **COMMAND_WAIT_DELAY**
+  - Certain operations like refreshing and searching happen asynchronously.  
+  - This is the delay in seconds between checking the status of these operations for completion.
+  - By checking for these to complete before proceeding we can ensure we do not overload the command queue.
+  - Operations like refreshing update show metadata so this ensures those actions are fully completed before additional operations are performed.
+
+- **COMMAND_WAIT_ATTEMPTS**
+  - The number of attempts to wait for an operation to complete before giving up.  If a command times out the operation will be considered failed.
+
+- **MINIMUM_DOWNLOAD_QUEUE_SIZE**
+  - The minimum number of items in the download queue before a new hunt is initiated.  For example if set to `5` then a new hunt will only start when there are 5 or less items marked as `downloading` in the queue.
+  - This helps prevent overwhelming the queue with too many download requests at once and avoids creating a massive backlog of downloads.
+  - Set to `-1` to disable this check.
 
 ---
 

--- a/config.py
+++ b/config.py
@@ -46,6 +46,27 @@ except ValueError:
     STATE_RESET_INTERVAL_HOURS = 168
     print(f"Warning: Invalid STATE_RESET_INTERVAL_HOURS value, using default: {STATE_RESET_INTERVAL_HOURS}")
 
+# Delay in seconds between checking the status of a command (default 1 second)
+try:
+    COMMAND_WAIT_DELAY = int(os.environ.get("COMMAND_WAIT_DELAY", "1"))
+except ValueError:
+    COMMAND_WAIT_DELAY = 1
+    print(f"Warning: Invalid COMMAND_WAIT_DELAY value, using default: {COMMAND_WAIT_DELAY}")
+
+# Number of attempts to wait for a command to complete before giving up (default 600 attempts)
+try:
+    COMMAND_WAIT_ATTEMPTS = int(os.environ.get("COMMAND_WAIT_ATTEMPTS", "600"))
+except ValueError:
+    COMMAND_WAIT_ATTEMPTS = 600
+    print(f"Warning: Invalid COMMAND_WAIT_ATTEMPTS value, using default: {COMMAND_WAIT_ATTEMPTS}")
+
+# Minimum size of the download queue before starting a hunt (default -1)
+try:
+    MINIMUM_DOWNLOAD_QUEUE_SIZE = int(os.environ.get("MINIMUM_DOWNLOAD_QUEUE_SIZE", "-1"))
+except ValueError:
+    MINIMUM_DOWNLOAD_QUEUE_SIZE = -1
+    print(f"Warning: Invalid MINIMUM_DOWNLOAD_QUEUE_SIZE value, using default: {MINIMUM_DOWNLOAD_QUEUE_SIZE}")
+
 # Selection Settings
 RANDOM_SELECTION = os.environ.get("RANDOM_SELECTION", "true").lower() == "true"
 MONITORED_ONLY = os.environ.get("MONITORED_ONLY", "true").lower() == "true"
@@ -64,6 +85,8 @@ def log_configuration(logger):
     logger.info(f"Missing Content Configuration: HUNT_MISSING_SHOWS={HUNT_MISSING_SHOWS}")
     logger.info(f"Upgrade Configuration: HUNT_UPGRADE_EPISODES={HUNT_UPGRADE_EPISODES}")
     logger.info(f"State Reset Interval: {STATE_RESET_INTERVAL_HOURS} hours")
+    logger.info(f"Minimum Download Queue Size: {MINIMUM_DOWNLOAD_QUEUE_SIZE}")
     logger.info(f"MONITORED_ONLY={MONITORED_ONLY}, RANDOM_SELECTION={RANDOM_SELECTION}")
     logger.info(f"HUNT_MODE={HUNT_MODE}, SLEEP_DURATION={SLEEP_DURATION}s")
+    logger.info(f"COMMAND_WAIT_DELAY={COMMAND_WAIT_DELAY}, COMMAND_WAIT_ATTEMPTS={COMMAND_WAIT_ATTEMPTS}")
     logger.debug(f"API_KEY={API_KEY}")

--- a/missing.py
+++ b/missing.py
@@ -93,20 +93,18 @@ def process_missing_episodes() -> bool:
         # Refresh the series
         logger.info(f" - Refreshing series (ID: {series_id})...")
         refresh_res = refresh_series(series_id)
-        if not refresh_res or "id" not in refresh_res:
+        if not refresh_res:
             logger.warning(f"WARNING: Refresh command failed for {show_title}. Skipping.")
-            time.sleep(5)
             continue
 
-        logger.info(f"Refresh command accepted (ID: {refresh_res['id']}). Waiting 5s...")
-        time.sleep(5)
+        logger.info(f"Refresh command completed successfully.")
 
         # Search specifically for these missing + monitored episodes
         episode_ids = [ep["id"] for ep in monitored_missing_episodes]
         logger.info(f" - Searching for {len(episode_ids)} missing episodes in '{show_title}'...")
         search_res = episode_search_episodes(episode_ids)
-        if search_res and "id" in search_res:
-            logger.info(f"Search command accepted (ID: {search_res['id']}).")
+        if search_res:
+            logger.info(f"Search command completed successfully.")
             processing_done = True
         else:
             logger.warning(f"WARNING: EpisodeSearch failed for show '{show_title}' (ID: {series_id}).")

--- a/upgrade.py
+++ b/upgrade.py
@@ -103,19 +103,17 @@ def process_cutoff_upgrades() -> bool:
             # Refresh the series
             logger.info(" - Refreshing series information...")
             refresh_res = refresh_series(series_id)
-            if not refresh_res or "id" not in refresh_res:
+            if not refresh_res:
                 logger.warning("WARNING: Refresh command failed. Skipping this episode.")
-                time.sleep(10)
                 continue
-
-            logger.info(f"Refresh command accepted (ID: {refresh_res['id']}). Waiting 5s...")
-            time.sleep(5)
+            
+            logger.info(f"Refresh command completed successfully.")
 
             # Search for the episode (upgrade)
             logger.info(" - Searching for quality upgrade...")
             search_res = episode_search_episodes([episode_id])
-            if search_res and "id" in search_res:
-                logger.info(f"Search command accepted (ID: {search_res['id']}).")
+            if search_res:
+                logger.info(f"Search command completed successfully.")
                 # Mark processed
                 save_processed_id(PROCESSED_UPGRADE_FILE, episode_id)
                 episodes_processed += 1
@@ -123,7 +121,6 @@ def process_cutoff_upgrades() -> bool:
                 logger.info(f"Processed {episodes_processed}/{HUNT_UPGRADE_EPISODES} upgrade episodes this cycle.")
             else:
                 logger.warning(f"WARNING: Search command failed for episode ID {episode_id}.")
-                time.sleep(10)
                 continue
 
         # Move to the next page if not random


### PR DESCRIPTION
- Wait for commands to complete to avoid overloading the command queue
- Add a minimum donwload queue size to avoid overloading the download queue

If this looks good to you I'll add the same for ~~Radarr~~ (https://github.com/plexguide/Huntarr-Radarr/pull/10) and Lidarr.

Let me know if you want any changes made as well.

I added the minimum download queue size because I don't want the download queue getting super backed up with a huge backlog of downloads.  This way I can run it on a 60 second cycle (`SLEEP_DURATION=60`) and as soon as the download queue count falls below something like 5 (for example) it will do more searches/upgrades.

I had it default to the `-1` value to maintain backward compatibility as that will disable the minimum queue size check.